### PR TITLE
Upgrade node-hid from 0.4.0 to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Streaming HID events in Node.js",
   "main": "index.js",
   "dependencies": {
-    "node-hid": "^0.4.0"
+    "node-hid": "^0.5.1"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
This should make it installable on Linux with node version 4 and 6.